### PR TITLE
Various bit fixing

### DIFF
--- a/microcosm_caching/memcached.py
+++ b/microcosm_caching/memcached.py
@@ -77,8 +77,8 @@ class MemcachedCache(CacheBase):
             server=(host, port),
             connect_timeout=connect_timeout,
             timeout=read_timeout,
-            serializer=json_serializer,
-            deserializer=json_deserializer,
+            serializer=serializer,
+            deserializer=deserializer,
         )
 
         if testing:

--- a/microcosm_caching/memcached.py
+++ b/microcosm_caching/memcached.py
@@ -80,16 +80,19 @@ class MemcachedCache(CacheBase):
             serializer=json_serializer,
             deserializer=json_deserializer,
         )
+
         if testing:
             self.client = MockMemcacheClient(**client_kwargs)
         else:
             self.client = Client(**client_kwargs)
 
-    def get(self, key):
+    def get(self, key: str):
         return self.client.get(key)
 
-    def set(self, key, value, ttl=None):
+    def set(self, key: str, value, ttl=None):
         if ttl is None:
             # pymemcache interprets 0 as no expiration
             ttl = 0
+        # NB: If input is malformed, this will not raise errors.
+        # set `noreply` to False for further debugging
         return self.client.set(key, value, expire=ttl)

--- a/microcosm_caching/memcached.py
+++ b/microcosm_caching/memcached.py
@@ -33,9 +33,9 @@ def json_serializer(key, value):
 
     """
     if isinstance(value, str) or isinstance(value, bytes):
-        return value, SerializationFlag.STRING
+        return value, SerializationFlag.STRING.value
 
-    return dumps(value), SerializationFlag.JSON
+    return dumps(value), SerializationFlag.JSON.value
 
 
 def json_deserializer(key, value, flags):

--- a/microcosm_caching/tests/test_factories.py
+++ b/microcosm_caching/tests/test_factories.py
@@ -6,6 +6,8 @@ from hamcrest import assert_that, equal_to, is_
 from microcosm.api import create_object_graph, load_from_dict
 from parameterized import parameterized
 
+from microcosm_caching.factories import parse_server_config
+
 
 class TestResourceCacheFactory:
 
@@ -34,4 +36,12 @@ class TestResourceCacheFactory:
         assert_that(
             self.graph.resource_cache.get(key),
             is_(equal_to(value)),
+        )
+
+    def test_parse_server_config(self):
+        assert_that(
+            parse_server_config(["server1:11211", "server2:22122"]),
+            is_(
+                [["server1", "11211"], ["server2", "22122"]],
+            ),
         )

--- a/microcosm_caching/tests/test_factories.py
+++ b/microcosm_caching/tests/test_factories.py
@@ -29,9 +29,9 @@ class TestResourceCacheFactory:
         )),
     ])
     def test_set_and_get_value_when_resource_cache_is_enabled(self, key, value):
-        self.graph.resource_cache.set("key", value)
+        self.graph.resource_cache.set(key, value)
 
         assert_that(
-            self.graph.resource_cache.get("key"),
+            self.graph.resource_cache.get(key),
             is_(equal_to(value)),
         )

--- a/microcosm_caching/tests/test_serializers.py
+++ b/microcosm_caching/tests/test_serializers.py
@@ -1,0 +1,26 @@
+from json import dumps
+
+from hamcrest import assert_that, is_
+from parameterized import parameterized
+
+from microcosm_caching.memcached import (
+    SerializationFlag,
+    json_deserializer,
+    json_serializer,
+)
+
+
+@parameterized([
+    ("key", "string-value", ("string-value", SerializationFlag.STRING.value)),
+    ("key", dict(foo="bar"), (dumps(dict(foo="bar")), SerializationFlag.JSON.value)),
+])
+def test_serializer(key, value, result):
+    assert_that(json_serializer(key, value), is_(result))
+
+
+@parameterized([
+    ("key", "string-value", SerializationFlag.STRING.value, "string-value"),
+    ("key", dumps(dict(foo="bar")), SerializationFlag.JSON.value, dict(foo="bar")),
+])
+def test_deserializer(key, value, flag, expected_value):
+    assert_that(json_deserializer(key, value, flag), is_(expected_value))

--- a/microcosm_caching/tests/test_serializers.py
+++ b/microcosm_caching/tests/test_serializers.py
@@ -3,11 +3,7 @@ from json import dumps
 from hamcrest import assert_that, is_
 from parameterized import parameterized
 
-from microcosm_caching.memcached import (
-    SerializationFlag,
-    json_deserializer,
-    json_serializer,
-)
+from microcosm_caching.memcached import SerializationFlag, json_deserializer, json_serializer
 
 
 @parameterized([


### PR DESCRIPTION
* Use HashClient instead of base client
  The main expected setup here will be a cluster of caches, not a single one.

* Use the passed-in de/serializers

* Add note about noreply
  Noreply apparently provides some nice performance boosts, but does mask 
  errors. In the case of seemingly odd errors, turn it off to debug.

* Fix serialization
  This otherwise causes `set` calls to break; the enum key itself was being
  passed into the `set` command instead of the int value.