### PR TITLE
Fix server config

### DIFF
--- a/microcosm_caching/factories.py
+++ b/microcosm_caching/factories.py
@@ -33,4 +33,9 @@ def configure_resource_cache(graph):
 
 def parse_server_config(servers):
     # NB: Assume input of the form: ["host:port","host:port"]
-    return [server.split(":") for server in servers]
+    parsed_servers = []
+    for server in servers:
+        host, port = server.split(":")
+        parsed_servers.append((host, int(port)))
+
+    return parsed_servers

--- a/microcosm_caching/tests/test_factories.py
+++ b/microcosm_caching/tests/test_factories.py
@@ -42,6 +42,6 @@ class TestResourceCacheFactory:
         assert_that(
             parse_server_config(["server1:11211", "server2:22122"]),
             is_(
-                [["server1", "11211"], ["server2", "22122"]],
+                [("server1", 11211), ("server2", 22122)],
             ),
         )


### PR DESCRIPTION
This was due to a misreading of the server configuration code; the
client explicitly expects an int-based port.