### PR TITLE
GLOB-38346 Add basic caching retrieve decorator

### DIFF
--- a/microcosm_caching/decorators.py
+++ b/microcosm_caching/decorators.py
@@ -26,14 +26,22 @@ def cache_key(cache_prefix, key):
 
 def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAULT_TTL):
     """
-    Intended mainly for use as a decorator around microcosm_flask.CRUDStoreAdapters, namely
-    those revolving around retrieve functions, such that the resource is identifiable
-    by a single ID.
+    Caches the result of a decorated component function, given that the both the underlying
+    function and the component itself adhere to a given structure.
 
     Decorated components must expose:
       * an identifier_key function
       * a logger reference
       * the graph
+
+    The cached resource must be:
+      * Adhere to a given Schema resource
+      * Be identifiable by a single ID
+
+    Main usage expected here is for a CRUDStoreAdapter subclass, but may be usable in other contexts as well.
+
+    Example usage:
+        cached(component, ConcreteSchema, "prefix")(component.retrieve)
 
     :param component: A microcosm-based controller component
     :param schema: The schema corresponding to the response type of the component

--- a/microcosm_caching/decorators.py
+++ b/microcosm_caching/decorators.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from logging import Logger
 from time import perf_counter
-from typing import Any, Optional, Type
+from typing import Any, Type
 
 from marshmallow import Schema
 from microcosm.errors import NotBoundError
@@ -46,7 +46,7 @@ def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAUL
 
     graph = component.graph
     metrics = get_metrics(graph)
-    resource_cache: Optional[CacheBase] = graph.resource_cache
+    resource_cache: CacheBase = graph.resource_cache
 
     def retrieve_from_cache(key: str):
         start_time = perf_counter()
@@ -98,7 +98,7 @@ def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAUL
                 if not cached_resource:
                     resource = func(*args, **kwargs)
                     cached_resource = schema().dump(resource)
-                    set_in_cache( key, cached_resource )
+                    set_in_cache(key, cached_resource)
 
                 # NB: We're caching the serialized format of the resource, meaning
                 # we need to do a (wasteful) load here to enable it to be dumped correctly
@@ -110,5 +110,3 @@ def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAUL
 
         return cache
     return decorator
-
-

--- a/microcosm_caching/decorators.py
+++ b/microcosm_caching/decorators.py
@@ -1,0 +1,126 @@
+from functools import wraps
+from logging import Logger
+from time import perf_counter
+from typing import Any, Optional, Type
+
+from marshmallow import Schema
+from microcosm.errors import NotBoundError
+from pymemcache.exceptions import MemcacheError
+
+from microcosm_caching.base import CacheBase
+
+
+DEFAULT_TTL = 60 * 60  # Cache for an hour by default
+
+
+def get_metrics(graph):
+    try:
+        return graph.metrics
+    except NotBoundError:
+        return None
+
+
+def cache_key(cache_prefix, key):
+    return f"{cache_prefix}:{key}"
+
+
+def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAULT_TTL):
+    """
+    Intended mainly for use as a decorator around microcosm_flask.CRUDStoreAdapters, namely
+    those revolving around retrieve functions, such that the resource is identifiable
+    by a single ID.
+
+    Decorated components must expose:
+      * an identifier_key function
+      * a logger reference
+      * the graph
+
+    :param component: A microcosm-based controller component
+    :param schema: The schema corresponding to the response type of the component
+    :param cache_prefix: Namespace to use for cache keys
+    :param ttl: How long to cache the underlying resource
+    :return:
+    """
+    identifier_key: str = getattr(component, "identifier_key")
+    logger: Logger = getattr(component, "logger")
+
+    graph = component.graph
+    metrics = get_metrics(graph)
+    resource_cache: Optional[CacheBase] = graph.resource_cache
+
+    def decorator(func):
+        @wraps(func)
+        def cache(*args, **kwargs) -> Schema:
+            if not resource_cache:
+                return func(*args, **kwargs)
+
+            try:
+                key = cache_key(cache_prefix, kwargs[identifier_key])
+                cached_resource = retrieve_from_cache(
+                    key,
+                    resource_cache,
+                    metrics,
+                    schema,
+                )
+                if not cached_resource:
+                    resource = func(*args, **kwargs)
+                    cached_resource = schema().dump(resource)
+                    set_in_cache(
+                        key,
+                        cached_resource,
+                        resource_cache,
+                        metrics,
+                        schema,
+                        ttl=ttl,
+                    )
+
+                # NB: We're caching the serialized format of the resource, meaning
+                # we need to do a (wasteful) load here to enable it to be dumped correctly
+                # later on in the flow. This could probably be made more efficient
+                return schema().load(cached_resource, unknown="exclude")
+            except (MemcacheError, ConnectionRefusedError) as error:
+                logger.warning("Unable to retrieve/save cache data", extra=dict(error=error))
+                return func(*args, **kwargs)
+
+        return cache
+    return decorator
+
+
+def retrieve_from_cache(key: str, resource_cache, metrics, schema):
+    start_time = perf_counter()
+
+    resource = resource_cache.get(key)
+
+    elapsed_ms = (perf_counter() - start_time) * 1000
+
+    if metrics:
+        tags = [
+            "action:get",
+            f"resource:{schema.__name__}",
+        ]
+
+        metrics.timing("cache_timing", elapsed_ms, tags=tags)
+
+        if resource:
+            metrics.increment("cache_hit", tags=tags)
+        else:
+            metrics.increment("cache_miss", tags=tags)
+
+    return resource
+
+
+def set_in_cache(key: str, value: Any, resource_cache: CacheBase, metrics, schema, ttl=None) -> None:
+    start_time = perf_counter()
+
+    resource_cache.set(key, value, ttl=ttl)
+
+    elapsed_ms = (perf_counter() - start_time) * 1000
+
+    if metrics:
+        tags = [
+            "action:set",
+            f"resource:{schema.__name__}",
+        ]
+
+        metrics.timing("cache_timing", elapsed_ms, tags=tags)
+        metrics.increment("cache_set", tags=tags)

--- a/microcosm_caching/decorators.py
+++ b/microcosm_caching/decorators.py
@@ -39,7 +39,7 @@ def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAUL
     :param schema: The schema corresponding to the response type of the component
     :param cache_prefix: Namespace to use for cache keys
     :param ttl: How long to cache the underlying resource
-    :return:
+    :return: the resource (i.e. loaded schema instance)
     """
     identifier_key: str = getattr(component, "identifier_key")
     logger: Logger = getattr(component, "logger")

--- a/microcosm_caching/tests/test_decorators.py
+++ b/microcosm_caching/tests/test_decorators.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for decorators
+
+"""
+from hamcrest import assert_that, is_
+from marshmallow import Schema, fields
+from microcosm.api import binding, create_object_graph, load_from_dict
+from microcosm_logging.decorators import logger
+
+from microcosm_caching.decorators import cached
+
+
+class TestSchema(Schema):
+    key = fields.String(required=True)
+
+
+@binding("controller")
+@logger
+class TestController:
+    def __init__(self, graph):
+        self.graph = graph
+
+    def retrieve(self, **kwargs):
+        return {"key": "value"}
+
+    @property
+    def identifier_key(self):
+        return "key_id"
+
+
+class TestDecorators:
+
+    def setup(self):
+        self.graph = create_object_graph(
+            "test",
+            testing=True,
+            loader=load_from_dict(dict(
+                resource_cache=dict(enabled=True),
+            )),
+        )
+        self.graph.use(
+            "controller",
+        )
+        controller = self.graph.controller
+        self.cached_retrieve = cached(controller, TestSchema, "test")(controller.retrieve)
+
+    def test_decorator(self):
+        self.cached_retrieve(key_id=1)
+        assert_that(
+            self.graph.resource_cache.get("test:1"),
+            is_({"key": "value"}),
+        )


### PR DESCRIPTION
Adds a new decorator for microcosm_flask-based controllers, to be used
on basic entity retrieves.

Notes on implementation: This is a bit tightly coupled to expectations on how the controllers of today currently behave / are configured. This may not be ideal, given how ubiquitous usage of this decorator may become. This is slightly less optimal than the current `transactional` decorator, which does a basic "begin/end" transaction.

In terms of general implementation, this is a bog-standard "get and set" caching operation. The main note of interest are how we de/serialize. I'm sure there's more that could be done to make this more generic, but this is intended to be a first pass on this front.

Sidenote: I will want to expose a couple more types of decorators eventually:
* deletion / invalidation
* search result caching