### PR TITLE
Expand caching decorators to accommodate invalidation

### DIFF
--- a/microcosm_caching/base.py
+++ b/microcosm_caching/base.py
@@ -23,3 +23,24 @@ class CacheBase(ABC):
 
         """
         pass
+
+    @abstractmethod
+    def set_many(self, values, ttl=None):
+        """
+        Set key/value pairs in the cache
+
+        Optional ttl (time-to-live) value should be in seconds.
+
+        """
+        pass
+
+    @abstractmethod
+    def add(self, key, value, ttl=None):
+        """
+        Add a key, value pair to the cache, skipping the set if
+        the key has already been set
+
+        Optional ttl (time-to-live) value should be in seconds.
+
+        """
+        pass

--- a/microcosm_caching/decorators.py
+++ b/microcosm_caching/decorators.py
@@ -11,7 +11,7 @@ from microcosm_caching.base import CacheBase
 
 
 DEFAULT_TTL = 60 * 60  # Cache for an hour by default
-DEFAULT_LOCK_TTL = 3  # Stop incoming writes for 5 seconds by default
+DEFAULT_LOCK_TTL = 3  # Stop incoming writes for 3 seconds by default
 
 
 def get_metrics(graph):

--- a/microcosm_caching/decorators.py
+++ b/microcosm_caching/decorators.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from logging import Logger
 from time import perf_counter
-from typing import Any, Type
+from typing import Any, Dict, Type
 
 from marshmallow import Schema
 from microcosm.errors import NotBoundError
@@ -11,6 +11,7 @@ from microcosm_caching.base import CacheBase
 
 
 DEFAULT_TTL = 60 * 60  # Cache for an hour by default
+DEFAULT_LOCK_TTL = 3  # Stop incoming writes for 5 seconds by default
 
 
 def get_metrics(graph):
@@ -20,7 +21,15 @@ def get_metrics(graph):
         return None
 
 
-def cache_key(cache_prefix, key):
+def cache_key(cache_prefix, schema, args, kwargs) -> str:
+    """
+    Hash a key according to the schema and input args.
+
+    """
+    key = (schema.__name__,) + args
+    key += tuple(sorted((a, b) for a, b in kwargs.items()))
+    key = hash(key)
+
     return f"{cache_prefix}:{key}"
 
 
@@ -43,13 +52,12 @@ def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAUL
     Example usage:
         cached(component, ConcreteSchema, "prefix")(component.retrieve)
 
-    :param component: A microcosm-based controller component
+    :param component: A microcosm-based component
     :param schema: The schema corresponding to the response type of the component
     :param cache_prefix: Namespace to use for cache keys
     :param ttl: How long to cache the underlying resource
     :return: the resource (i.e. loaded schema instance)
     """
-    identifier_key: str = getattr(component, "identifier_key")
     logger: Logger = getattr(component, "logger")
 
     graph = component.graph
@@ -78,21 +86,21 @@ def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAUL
 
         return resource
 
-    def set_in_cache(key: str, value: Any) -> None:
+    def add_in_cache(key: str, value: Any) -> None:
         start_time = perf_counter()
 
-        resource_cache.set(key, value, ttl=ttl)
+        resource_cache.add(key, value, ttl=ttl)
 
         elapsed_ms = (perf_counter() - start_time) * 1000
 
         if metrics:
             tags = [
-                "action:set",
+                "action:add",
                 f"resource:{schema.__name__}",
             ]
 
             metrics.timing("cache_timing", elapsed_ms, tags=tags)
-            metrics.increment("cache_set", tags=tags)
+            metrics.increment("cache_add", tags=tags)
 
     def decorator(func):
         @wraps(func)
@@ -101,12 +109,12 @@ def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAUL
                 return func(*args, **kwargs)
 
             try:
-                key = cache_key(cache_prefix, kwargs[identifier_key])
+                key = cache_key(cache_prefix, schema, args, kwargs)
                 cached_resource = retrieve_from_cache(key)
                 if not cached_resource:
                     resource = func(*args, **kwargs)
                     cached_resource = schema().dump(resource)
-                    set_in_cache(key, cached_resource)
+                    add_in_cache(key, cached_resource)
 
                 # NB: We're caching the serialized format of the resource, meaning
                 # we need to do a (wasteful) load here to enable it to be dumped correctly
@@ -115,6 +123,76 @@ def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAUL
             except (MemcacheError, ConnectionRefusedError) as error:
                 logger.warning("Unable to retrieve/save cache data", extra=dict(error=error))
                 return func(*args, **kwargs)
+
+        return cache
+    return decorator
+
+
+def invalidates(
+    component,
+    invalidations,
+    cache_prefix,
+    lock_ttl=DEFAULT_LOCK_TTL
+):
+    """
+    Invalidates a set of prescribed keys, based on a combination of:
+        * specified arguments
+        * schema
+
+    Note: this does require that the input args to the given function correspond to the
+    invalidation args given. As such, using it conjunction with certain functions (such as
+    a plain delete) may not provide sufficient context for invalidation, and caching should
+    not be used in such scenarios.
+
+    """
+    graph = component.graph
+    metrics = get_metrics(graph)
+    resource_cache: CacheBase = graph.resource_cache
+
+    def delete_from_cache(values) -> None:
+        """
+        "Delete" from cache by locking writes to a key for a designated
+        amount of time.
+
+        In conjunction with the cached() decorator, this allows the "get and set"
+        flow to behave without special cases
+
+        """
+        start_time = perf_counter()
+
+        resource_cache.set_many(values, ttl=lock_ttl)
+
+        elapsed_ms = (perf_counter() - start_time) * 1000
+
+        if metrics:
+            tags = [
+                "action:set_many",
+            ]
+
+            metrics.timing("cache_timing", elapsed_ms, tags=tags)
+            metrics.increment("cache_set_many", tags=tags)
+
+    def decorator(func):
+        @wraps(func)
+        def cache(*args, **kwargs) -> Schema:
+            if not resource_cache:
+                return func(*args, **kwargs)
+
+            values: Dict[str, None] = {}
+            for schema, invalidation_kwargs in invalidations:
+                # NB: We assume that we don't cache via args
+                key = cache_key(cache_prefix, schema, (), {
+                    invalidation_kwarg: kwargs[invalidation_kwarg]
+                    for invalidation_kwarg in invalidation_kwargs
+                })
+                values[key] = None
+
+            result = func(*args, **kwargs)
+            # NB: Exceptions raised from cache operations aren't caught here;
+            # This will prevent stale data from persisting after request completion
+            delete_from_cache(values)
+
+            return result
 
         return cache
     return decorator

--- a/microcosm_caching/memcached.py
+++ b/microcosm_caching/memcached.py
@@ -92,12 +92,43 @@ class MemcachedCache(CacheBase):
             )
 
     def get(self, key: str):
+        """
+        Return the value for a key, or None if not found
+
+        """
         return self.client.get(key)
 
+    def add(self, key: str, value, ttl=None):
+        """
+        Set the value for a key, but only that key hasn't been set.
+
+        """
+        if ttl is None:
+            # pymemcache interprets 0 as no expiration
+            ttl = 0
+        # NB: If input is malformed, this will not raise errors.
+        # set `noreply` to False for further debugging
+        return self.client.add(key, value, expire=ttl)
+
     def set(self, key: str, value, ttl=None):
+        """
+        Set the value for a key, but overwriting existing values
+
+        """
         if ttl is None:
             # pymemcache interprets 0 as no expiration
             ttl = 0
         # NB: If input is malformed, this will not raise errors.
         # set `noreply` to False for further debugging
         return self.client.set(key, value, expire=ttl)
+
+    def set_many(self, values, ttl=None):
+        """
+        Set the many key-value pairs at a time, overwriting existing values
+
+        """
+        if ttl is None:
+            # pymemcache interprets 0 as no expiration
+            ttl = 0
+
+        return self.client.set_many(values, expire=ttl)

--- a/microcosm_caching/tests/test_decorators.py
+++ b/microcosm_caching/tests/test_decorators.py
@@ -7,11 +7,20 @@ from marshmallow import Schema, fields
 from microcosm.api import binding, create_object_graph, load_from_dict
 from microcosm_logging.decorators import logger
 
-from microcosm_caching.decorators import cache_key, cached, invalidates
+from microcosm_caching.decorators import (
+    Invalidation,
+    cache_key,
+    cached,
+    invalidates,
+)
 
 
 class TestSchema(Schema):
     key = fields.String(required=True)
+
+
+class TestExtendedSchema(Schema):
+    extended_key = fields.String(required=True)
 
 
 class TestForSchema(Schema):
@@ -28,16 +37,15 @@ class TestController:
     def retrieve(self, **kwargs):
         return {"key": "value"}
 
+    def extended_retrieve(self, **kwargs):
+        return {"extended_key": "value"}
+
     def create(self, **kwargs):
         return
 
     def retrieve_for(self, **kwargs):
         self.calls += 1
         return {"values": self.calls}
-
-    @property
-    def identifier_key(self):
-        return "key_id"
 
 
 class TestDecorators:
@@ -57,10 +65,37 @@ class TestDecorators:
         controller = self.graph.controller
 
         self.cached_retrieve = cached(controller, TestSchema, self.cache_prefix)(controller.retrieve)
+        self.cached_extended_retrieve = cached(
+            controller,
+            TestExtendedSchema,
+            self.cache_prefix,
+        )(controller.extended_retrieve)
 
         self.cached_create = invalidates(
             controller,
-            invalidations=[(TestForSchema, ("key_id",))],
+            invalidations=[
+                Invalidation(
+                    schema=TestForSchema,
+                    arguments=[
+                        "key_id",
+                    ],
+                ),
+                Invalidation(
+                    schema=TestSchema,
+                    arguments=[
+                        "key_id",
+                    ],
+                ),
+                Invalidation(
+                    schema=TestExtendedSchema,
+                    arguments=[
+                        "extended_key_id",
+                    ],
+                    kwarg_mappings=dict(
+                        extended_key_id="key_id",
+                    ),
+                ),
+            ],
             cache_prefix=self.cache_prefix,
         )(controller.create)
 
@@ -76,24 +111,35 @@ class TestDecorators:
 
     def test_invalidates(self):
         # Validate that we cache between requests
-        first_call = self.cached_retrieve_for(key_id=1)
-        second_call = self.cached_retrieve_for(key_id=1)
+        first_call = self.cached_retrieve_for(key_id=1, other_key_id=2)
+        second_call = self.cached_retrieve_for(key_id=1, other_key_id=2)
         assert_that(first_call["values"], is_(second_call["values"]))
 
-        key = cache_key(self.cache_prefix, TestForSchema, (), dict(key_id=1))
+        key = cache_key(self.cache_prefix, TestForSchema, (), dict(key_id=1, other_key_id=2))
         assert_that(
             self.graph.resource_cache.get(key),
             is_({"values": 1}),
         )
 
+        # Then populate the basic retrieve key
+        self.cached_retrieve(key_id=1)
+
+        # And the extended key
+        self.cached_extended_retrieve(extended_key_id=1)
+
         self.cached_create(key_id=1)
 
-        # And check that
-        key = cache_key(self.cache_prefix, TestForSchema, (), dict(key_id=1))
-        assert_that(
-            self.graph.resource_cache.get(key),
-            is_(None),
-        )
+        # And check that all keys are marked for deletion
+        for schema, kwargs in (
+            (TestSchema, dict(key_id=1)),
+            (TestForSchema, dict(key_id=1)),
+            (TestExtendedSchema, dict(extended_key_id=1)),
+        ):
+            key = cache_key(self.cache_prefix, schema, (), kwargs)
+            assert_that(
+                self.graph.resource_cache.get(key),
+                is_(None),
+            )
 
         # Then validate that it was invalidated correctly
         assert_that(self.cached_retrieve_for(key_id=1)["values"], is_(first_call["values"] + 1))

--- a/microcosm_caching/tests/test_decorators.py
+++ b/microcosm_caching/tests/test_decorators.py
@@ -7,11 +7,15 @@ from marshmallow import Schema, fields
 from microcosm.api import binding, create_object_graph, load_from_dict
 from microcosm_logging.decorators import logger
 
-from microcosm_caching.decorators import cached
+from microcosm_caching.decorators import cache_key, cached, invalidates
 
 
 class TestSchema(Schema):
     key = fields.String(required=True)
+
+
+class TestForSchema(Schema):
+    values = fields.Integer(required=True)
 
 
 @binding("controller")
@@ -19,9 +23,17 @@ class TestSchema(Schema):
 class TestController:
     def __init__(self, graph):
         self.graph = graph
+        self.calls = 0
 
     def retrieve(self, **kwargs):
         return {"key": "value"}
+
+    def create(self, **kwargs):
+        return
+
+    def retrieve_for(self, **kwargs):
+        self.calls += 1
+        return {"values": self.calls}
 
     @property
     def identifier_key(self):
@@ -41,12 +53,47 @@ class TestDecorators:
         self.graph.use(
             "controller",
         )
+        self.cache_prefix = "test"
         controller = self.graph.controller
-        self.cached_retrieve = cached(controller, TestSchema, "test")(controller.retrieve)
 
-    def test_decorator(self):
+        self.cached_retrieve = cached(controller, TestSchema, self.cache_prefix)(controller.retrieve)
+
+        self.cached_create = invalidates(
+            controller,
+            invalidations=[(TestForSchema, ("key_id",))],
+            cache_prefix=self.cache_prefix,
+        )(controller.create)
+
+        self.cached_retrieve_for = cached(controller, TestForSchema, self.cache_prefix)(controller.retrieve_for)
+
+    def test_cached(self):
         self.cached_retrieve(key_id=1)
+        key = cache_key(self.cache_prefix, TestSchema, (), dict(key_id=1))
         assert_that(
-            self.graph.resource_cache.get("test:1"),
+            self.graph.resource_cache.get(key),
             is_({"key": "value"}),
         )
+
+    def test_invalidates(self):
+        # Validate that we cache between requests
+        first_call = self.cached_retrieve_for(key_id=1)
+        second_call = self.cached_retrieve_for(key_id=1)
+        assert_that(first_call["values"], is_(second_call["values"]))
+
+        key = cache_key(self.cache_prefix, TestForSchema, (), dict(key_id=1))
+        assert_that(
+            self.graph.resource_cache.get(key),
+            is_({"values": 1}),
+        )
+
+        self.cached_create(key_id=1)
+
+        # And check that
+        key = cache_key(self.cache_prefix, TestForSchema, (), dict(key_id=1))
+        assert_that(
+            self.graph.resource_cache.get(key),
+            is_(None),
+        )
+
+        # Then validate that it was invalidated correctly
+        assert_that(self.cached_retrieve_for(key_id=1)["values"], is_(first_call["values"] + 1))


### PR DESCRIPTION
While caching resources identifiable by only a single identifier is
useful, it's not as powerful as it could be. Namely, we can cache search
operations by a given set of arguments, and invalidate likewise, which
means we can now do more than just cache, say, retrieve operations.

Additionally, we can now have a dedicated way of invalidating said
resources based on known query args. At the time of validation, we'll
adopt a convention where keys are "locked" on deletion, and incoming
requests won't be able to set until the deleted key reaches its TTL.

There will thus need to be some care taken with which
endpoints/resources are cached. If, for example, the resource is being
searched via any given number of arbitrary arguments, then you would
need to account for all permutations. This could probably benefit from a
whitelist of arguments.

Note: This works via microcosm conventions, that incoming controllers are
always passed via kwargs. This could probably be expanded via inspection,
but I'm choosing to kick that can down the road for the moment given
that it won't actually be used by any service we run today.