### PR TITLE
Use simplejson for de/serializing json values

### DIFF
--- a/microcosm_caching/memcached.py
+++ b/microcosm_caching/memcached.py
@@ -3,7 +3,7 @@ Serialization helpers for caching.
 
 """
 from enum import IntEnum, unique
-from json import dumps, loads
+from simplejson import dumps, loads
 from typing import Optional, Tuple
 
 from pymemcache.client.hash import HashClient

--- a/microcosm_caching/memcached.py
+++ b/microcosm_caching/memcached.py
@@ -3,11 +3,11 @@ Serialization helpers for caching.
 
 """
 from enum import IntEnum, unique
-from simplejson import dumps, loads
 from typing import Optional, Tuple
 
 from pymemcache.client.hash import HashClient
 from pymemcache.test.utils import MockMemcacheClient
+from simplejson import dumps, loads
 
 from microcosm_caching.base import CacheBase
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "microcosm>=2.12.0",
         "microcosm-logging>=1.3.0",
         "pymemcache>=2.2.2",
+        "simplejson>=3.16.0",
     ],
     extras_require={
         "metrics": "microcosm-metrics>=2.2.0",


### PR DESCRIPTION
While the default json module is good enough for most cases, it doesn't
handle all input types required for most microcosm modules.
Specifically, it fails to serialize decimal objects, which are used
extensively across a number of microcosm-flask APIs.

This matches the existing json module used in flask itself (itsdangerous
uses simplejson under the hood).