### PR TITLE
Add test to make sure that Decimal can serialize

### DIFF
--- a/microcosm_caching/tests/test_memcached.py
+++ b/microcosm_caching/tests/test_memcached.py
@@ -2,6 +2,7 @@
 Unit-tests for memcached cache backend.
 
 """
+from decimal import Decimal
 from time import sleep
 
 from hamcrest import assert_that, equal_to, is_
@@ -24,6 +25,7 @@ class TestMemcachedCache:
             nested=dict(nested_key="nested_value"),
             lst=["1", "2", "3"],
         )),
+        ("key", Decimal("10000.0")),
     ])
     def test_set_and_get_value(self, key, value):
         self.cache.set(key, value)


### PR DESCRIPTION
This was indeed the main purpose for introducing simplejson instead of
json.