### PR TITLE
Replace hash() with sha1() for key hashing

### DIFF
--- a/microcosm_caching/decorators.py
+++ b/microcosm_caching/decorators.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from functools import wraps
+from hashlib import sha1
 from logging import Logger
 from time import perf_counter
 from typing import (
@@ -64,9 +65,8 @@ def cache_key(cache_prefix, schema, args, kwargs) -> str:
     """
     key = (schema.__name__,) + args
     key += tuple(sorted((a, b) for a, b in kwargs.items()))
-    key = hash(key)
 
-    return f"{cache_prefix}:{key}"
+    return sha1(f"{cache_prefix}:{key}".encode("utf-8")).hexdigest()
 
 
 def cached(component, schema: Type[Schema], cache_prefix: str, ttl: int = DEFAULT_TTL):


### PR DESCRIPTION
While `hash()` is a convenient hashing mechanism, it has the unfortunate
side-effect of making the hashing key non-deterministic across
processes. This means that different instances caching the same
resource/arguments may end up using different keys.

This change switches to using `sha1()`. This is similar to how we've
cached resources in the past (e.g. via `uuid5`), and should be
deterministic.

There are a couple of different options here (e.g. base64, md5). I
mainly decided on sha1 due to the aforementioned uuid5 comparison. That
said, there is technically a performance penalty here, which I measured
locally:

```
In [10]: timeit('from hashlib import sha1; k = "service:(\'Schema\', (\'id\', UUID(\'183662b6-f1cb-45fb-b435-9202bf1b359b\')))"; sha1(k.encode("utf-8")).hexdigest()')
Out[10]: 2.177611326999994
```

vs.

```
In [8]: timeit('from base64 import b64encode; k = "service:(\'Schema\', (\'id\', UUID(\'183662b6-f1cb-45fb-b435-9202bf1b359b\')))"; b64encode(bytes(k, "utf-8"))')
Out[8]: 1.7267876340000043
```

Where the number of iterations is 1MM by default. I don't believe it's a
big concern, but it's there.