### PR TITLE
Default cache_prefix to application name

### DIFF
--- a/microcosm_caching/tests/test_decorators.py
+++ b/microcosm_caching/tests/test_decorators.py
@@ -93,10 +93,9 @@ class TestDecorators:
                     ),
                 ),
             ],
-            cache_prefix=self.cache_prefix,
         )(controller.create)
 
-        self.cached_retrieve_for = cached(controller, TestForSchema, self.cache_prefix)(controller.retrieve_for)
+        self.cached_retrieve_for = cached(controller, TestForSchema)(controller.retrieve_for)
 
     def test_cached(self):
         self.cached_retrieve(key_id=1)

--- a/microcosm_caching/tests/test_decorators.py
+++ b/microcosm_caching/tests/test_decorators.py
@@ -64,12 +64,9 @@ class TestDecorators:
         self.cache_prefix = "test"
         controller = self.graph.controller
 
-        self.cached_retrieve = cached(controller, TestSchema, self.cache_prefix)(controller.retrieve)
-        self.cached_extended_retrieve = cached(
-            controller,
-            TestExtendedSchema,
-            self.cache_prefix,
-        )(controller.extended_retrieve)
+        self.cached_retrieve = cached(controller, TestSchema)(controller.retrieve)
+        self.cached_extended_retrieve = cached(controller, TestExtendedSchema)(controller.extended_retrieve)
+        self.cached_retrieve_for = cached(controller, TestForSchema)(controller.retrieve_for)
 
         self.cached_create = invalidates(
             controller,


### PR DESCRIPTION
The graph itself contains a reference to the name of the application,
which should be the same as what was being passed in here previously.

Keep the ability to override, but default sensibly.