### PR TITLE
Bump pymemcache version

### DIFF
--- a/microcosm_caching/memcached.py
+++ b/microcosm_caching/memcached.py
@@ -25,7 +25,7 @@ class SerializationFlag(IntEnum):
     JSON = 2
 
 
-class JsonSerde:
+class JsonSerializerDeserializer:
     """
     Simple JSON serializer for use with caching backends
     that only support string/bytes value storage.
@@ -69,7 +69,7 @@ class MemcachedCache(CacheBase):
         client_kwargs = dict(
             connect_timeout=connect_timeout,
             timeout=read_timeout,
-            serde=serde if serde is not None else JsonSerde(),
+            serde=serde or JsonSerializerDeserializer(),
         )
 
         if testing:

--- a/microcosm_caching/tests/test_serializers.py
+++ b/microcosm_caching/tests/test_serializers.py
@@ -3,7 +3,7 @@ from json import dumps
 from hamcrest import assert_that, is_
 from parameterized import parameterized
 
-from microcosm_caching.memcached import SerializationFlag, json_deserializer, json_serializer
+from microcosm_caching.memcached import JsonSerde, SerializationFlag
 
 
 @parameterized([
@@ -11,7 +11,7 @@ from microcosm_caching.memcached import SerializationFlag, json_deserializer, js
     ("key", dict(foo="bar"), (dumps(dict(foo="bar")), SerializationFlag.JSON.value)),
 ])
 def test_serializer(key, value, result):
-    assert_that(json_serializer(key, value), is_(result))
+    assert_that(JsonSerde().serialize(key, value), is_(result))
 
 
 @parameterized([
@@ -19,4 +19,4 @@ def test_serializer(key, value, result):
     ("key", dumps(dict(foo="bar")), SerializationFlag.JSON.value, dict(foo="bar")),
 ])
 def test_deserializer(key, value, flag, expected_value):
-    assert_that(json_deserializer(key, value, flag), is_(expected_value))
+    assert_that(JsonSerde().deserialize(key, value, flag), is_(expected_value))

--- a/microcosm_caching/tests/test_serializers.py
+++ b/microcosm_caching/tests/test_serializers.py
@@ -3,7 +3,7 @@ from json import dumps
 from hamcrest import assert_that, is_
 from parameterized import parameterized
 
-from microcosm_caching.memcached import JsonSerde, SerializationFlag
+from microcosm_caching.memcached import JsonSerializerDeserializer, SerializationFlag
 
 
 @parameterized([
@@ -11,7 +11,7 @@ from microcosm_caching.memcached import JsonSerde, SerializationFlag
     ("key", dict(foo="bar"), (dumps(dict(foo="bar")), SerializationFlag.JSON.value)),
 ])
 def test_serializer(key, value, result):
-    assert_that(JsonSerde().serialize(key, value), is_(result))
+    assert_that(JsonSerializerDeserializer().serialize(key, value), is_(result))
 
 
 @parameterized([
@@ -19,4 +19,4 @@ def test_serializer(key, value, result):
     ("key", dumps(dict(foo="bar")), SerializationFlag.JSON.value, dict(foo="bar")),
 ])
 def test_deserializer(key, value, flag, expected_value):
-    assert_that(JsonSerde().deserialize(key, value, flag), is_(expected_value))
+    assert_that(JsonSerializerDeserializer().deserialize(key, value, flag), is_(expected_value))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "marshmallow>=3.0.0",
         "microcosm>=2.12.0",
         "microcosm-logging>=1.3.0",
-        "pymemcache>=2.2.2",
+        "pymemcache>=3.0.0",
         "simplejson>=3.16.0",
     ],
     extras_require={


### PR DESCRIPTION
Following pymemcache release notes: https://github.com/pinterest/pymemcache/releases/tag/v3.0.0.